### PR TITLE
tests: Add support for OpenOCD and ST-Link target interfaces

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -47,19 +47,131 @@ For example:
 pytest . --working-dir=out --keep-build-files
 ```
 
-##  Running the Tests on Target Hardware
+## On-Target Testing
+
+> [!WARNING]
+> These instructions have been tested on Linux only. They should also work
+> on Windows and MacOS, but this hasn't been tested and some things may not work.
 
 By default, the tests only try compiling and linking programs against the
 runtimes; they do not run the resulting executables.
-
 If you want to also check that the executables run correctly on physical
-hardware, then you will need to configure pytest to tell it which target you
-want to test on, and which ports it should use to communicate with the board
-(via a debugger).
-The following sections provide instructions for running the tests on specific
-target boards.
+hardware, then you will also need:
+* a development board with the target you want to test on (e.g. Raspberry Pi Pico);
+* a debug probe connected to your target (e.g. J-link, ST-Link); and
+* software for your debug probe that can run a GDB server
+  (e.g. [J-Link software Pack](https://www.segger.com/downloads/jlink/),
+  [OpenOCD](https://openocd.org/),
+  [st-util](https://github.com/stlink-org/stlink)).
 
-### Testing on the RP2040 and RP2350
+The way on-target testing works is that the testsuite uses GDB to
+interface with the target via the debug probe's GDB server and uses it to send
+commands to download and run test programs on the target board, and check that
+the output from the program (via semihosting) matches the expected output.
+The specifics change depending on the debug probe and software used.
+
+Additional options to pass to pytest for on-target testing are:
+* `--target-board` configures the target that is being tested, e.g. `rp2040`
+* `--target-if` configures the method used to interface with the target. Available options:
+  * `jlink-gdbserver` (default): connect to the target via a J-Link GDB server
+  * `openocd-gdbserver`: connect to the target via OpenOCD's GDB server
+  * `st-util`: connect to the target using the st-util utility.
+* `--gdbserver-port`: configures the GDB server's port number to connect to.
+* `--text-io-port`: configures the port number to connect to for reading the
+  semihosting text output from the program running on the target.
+
+### On-Target Testing using J-Link
+
+Assuming you have a J-Link debug probe and are using the J-Link software pack,
+you can run the tests using the following steps:
+1. Connect the J-Link to the target board and ensure both are powered (see
+   the target-specific sections below for details).
+2. Launch the J-Link GDB server GUI (by running `JLinkGDBServerExe`),
+   select the appropriate target options for your target and debug probe, then
+   start the GDB server. Make a note of the GDB server port and the Telnet port
+   as you will need it in the next step.
+3. Run the tests:
+
+```sh
+pytest . \
+    --target-board=<target> \
+    --target-if=jlink-gdbserver \
+    --gdbserver-port=<gdb-port> \
+    --text-io-port<telnet-port>
+```
+
+Where:
+* `<target>` is the name of the runtime target you want to test (e.g. `rp2040`)
+* `<gdb-port>` is the J-Link GDB server port number
+* `<telnet-port>` is the J-Link GDB server telnet port number
+
+For example, to test on the RP2040 using a J-Link:
+
+```sh
+pytest . --target-board=rp2040 --target-if=jlink-gdbserver --gdbserver-port=2331 --text-io-port=2333
+```
+
+### On-Target Testing using OpenOCD
+
+> [!WARNING]
+> The OpenOCD interface seems to be quite unreliable, as OpenOCD tends to segfault
+> when the testsuite disconnects from the semihosting socket at the end of each
+> test. If you encounter segfaults with OpenOCD then you may need to run one
+> test at a time and restart OpenOCD after each test, or use a different GDB
+> server.
+
+1. Launch OpenOCD with the appropriate options for your debug interface and target,
+   and configure OpenOCD to enable semihosting and redirect it via TCP
+   For example, for the Nucleo-G474RE board (`stm32g4xx` target) with semihosting
+   output on port 4445:
+```sh
+openocd \
+    -f interface/stlink.cfg \
+    -f target/stm32g4x.cfg \
+    -c init \
+    -c "arm semihosting enable" \
+    -c "arm semihosting_redirect tcp 4445"
+```
+2. Run the tests:
+
+```sh
+pytest . \
+    --target-board=<target> \
+    --target-if=openocd-gdbserver \
+    --gdbserver-port=<gdb-port> \
+    --text-io-port<telnet-port>
+```
+
+Where:
+* `<target>` is the name of the runtime target you want to test (e.g. `rp2040`)
+* `<gdb-port>` is OpenOCD's GDB server port number (port 3333 by default)
+* `<telnet-port>` is OpenOCD's semihosting port number (e.g. 4445)
+
+For example, to test on the stm32g4xx (Nucleo-G474RE board):
+
+```sh
+pytest . --target-board=stm32g4xx --target-if=openocd-gdbserver --gdbserver-port=3333 --text-io-port=4445
+```
+
+### On-Target Testing using st-util
+
+For STM32 boards with an ST-Link debugger, the `st-util` tool from
+the open source [STLINK Tools](https://github.com/stlink-org/stlink) project
+can be used to connect to the board.
+
+Assuming that `st-util` is in your system PATH, you can run the testsuite
+directly (the testsuite will take care of launching `st-util`):
+```sh
+pytest . --target-board=<target> --target-if=st-util
+```
+
+For example, to test on the stm32g4xx (Nucleo-G474RE board):
+
+```sh
+pytest . --target-board=stm32g4xx --target-if=st-util
+```
+
+### Testing on the RP2040 and RP2350 with J-Link
 
 Running the tests on an RP2040 or RP2350 requires the following hardware:
  * A Raspberry Pi Pico board (for RP2040) or Raspberry Pi Pico 2 (for RP2350)
@@ -151,12 +263,20 @@ GDB server and telnet ports:
 
 **For RP2040:**
 ```sh
-pytest . --target-board=rp2040 --gdbserver-port=2331 --text-io-port=2333
+pytest . \
+    --target-board=rp2040 \
+    --target-if=jlink-gdbserver \
+    --gdbserver-port=2331 \
+    --text-io-port=2333
 ```
 
 **For RP2350:**
 ```sh
-pytest . --target-board=rp2350 --gdbserver-port=2331 --text-io-port=2333
+pytest . \
+    --target-board=rp2350 \
+    --target-if=jlink-gdbserver \
+    --gdbserver-port=2331 \
+    --text-io-port=2333
 ```
 
 Note that the above command will also run the "build only" tests. If you only
@@ -164,7 +284,12 @@ want to run the tests that execute on the target hardware, you can tell pytest
 to only run the `test_execute_on_target` tests:
 
 ```sh
-pytest . --target-board=rp2040 --gdbserver-port=2331 --text-io-port=2333 -k test_execute_on_target
+pytest . \
+    --target-board=rp2040 \
+    --target-if=jlink-gdbserver \
+    --gdbserver-port=2331 \
+    --text-io-port=2333
+    -k test_execute_on_target
 ```
 
 The test harnesses will take care of building each test, downloading & running
@@ -173,7 +298,7 @@ output.
 
 ### Testing on the nRF52840
 
-Running the tests on an RP2040 or RP2350 requires the following hardware:
+Running the tests on an nRF52840 requires the following hardware:
  * An nRF52840 Development Kit (nRF52840-DK)
 
 and the following software:
@@ -196,7 +321,29 @@ targeting (the nrf52840), and which ports to use to commuicate with the J-Link
 GDB server and telnet ports:
 
 ```sh
-pytest . --target-board=nrf52840 --gdbserver-port=2331 --text-io-port=2333 -k test_execute_on_target
+pytest . \
+    --target-board=nrf52840 \
+    --target-if=jlink-gdbserver \
+    --gdbserver-port=2331 \
+    --text-io-port=2333 \
+    -k test_execute_on_target
+```
+
+### Testing on the STM32G4xx
+
+Running the tests on an stm32g4xx requires the following hardware:
+ * A Nucleo-G474RE board
+
+And the following software installed and available on your system PATH:
+ * [STLINK Tools](https://github.com/stlink-org/stlink)
+
+Note that the Nucleo board comes with an on-board ST-Link debugger, so a separate
+debugger is not required. Simply connect to the USB connector on the board.
+
+Now you can run the tests:
+
+```sh
+pytest . --target-board=stm32g4xx --target-if=st-util -k test_execute_on_target
 ```
 
 ## How the Tests Work

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,16 @@
 import pytest
+import support.target_interface
+
 
 def pytest_addoption(parser):
+    parser.addoption(
+        "--target-if",
+        action="store",
+        type=str,
+        choices=support.target_interface.driver_classes.keys(),
+        default="jlink-gdbserver",
+        help="Selects the target interface to use to communicate with the board",
+    )
     parser.addoption(
         "--gdbserver-port",
         action="store",
@@ -35,21 +45,31 @@ def pytest_addoption(parser):
         help="Don't delete working files after the test is completed",
     )
 
+
+@pytest.fixture
+def target_if(request):
+    return request.config.getoption("--target-if")
+
+
 @pytest.fixture
 def gdbserver_port(request):
     return request.config.getoption("--gdbserver-port")
+
 
 @pytest.fixture
 def text_io_port(request):
     return request.config.getoption("--text-io-port")
 
+
 @pytest.fixture
 def target_board(request):
     return request.config.getoption("--target-board")
 
+
 @pytest.fixture
 def working_dir(request):
     return request.config.getoption("--working-dir")
+
 
 @pytest.fixture
 def keep_build_files(request):

--- a/tests/support/target_interface.py
+++ b/tests/support/target_interface.py
@@ -1,8 +1,10 @@
-import pathlib
 import os
+import pathlib
+import pygdbmi.constants
 import pygdbmi.gdbcontroller
 import select
 import shutil
+import signal
 import socket
 import subprocess
 import time
@@ -47,49 +49,37 @@ def find_gdb(crate_dir: pathlib.Path, target_triplet: str) -> pathlib.Path:
     return None if path is None else pathlib.Path(path)
 
 
-class GdbInterface:
-    """Provides operations to interact with GDB"""
+class GdbTargetInterface:
+    """
+    Interfaces with the target via GDB
 
-    def __init__(self, gdb_path: pathlib.Path, gdbserver_port: int):
-        """
-        Set up the GdbInterface
+    This starts a GDB instance using the GDB executable obtained from the
+    runtime crate's Alire environment, then connects it to an already-running
+    GDB server that is listening on the specified gdbserver_port.
 
-        :param gdb_path: Path to the GDB executable to use
-        :param gdbserver_port: The port number to use to connect to the local
-            GDB server
-        """
+    Text output from the program running on the target is optionally read from
+    a socket whose port is given by terminal_io_port.
+    """
 
-        self.gdb = pygdbmi.gdbcontroller.GdbController(
-            [str(gdb_path), "--interpreter=mi2"]
-        )
-        self.gdb.write(f"target remote :{gdbserver_port}")
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.gdb.exit()
-
-    def load(self, executable: pathlib.Path):
-        """Load an executable to the target"""
-        self.gdb.write(f"load {executable.absolute()}", timeout_sec=5)
-
-    def reset(self):
-        """Reset the target"""
-        self.gdb.write("monitor reset", timeout_sec=5)
-
-    def run(self):
-        """Run the program"""
-        self.gdb.write("continue")
-
-
-class JLinkInterface(GdbInterface):
     def __init__(
         self,
         runtime_crate_dir: pathlib.Path,
+        executable_file: pathlib.Path,
         gdbserver_port: int,
-        terminal_io_port: int,
+        terminal_io_port: Optional[int],
     ):
+        """
+        Set up the GdbTargetInterface
+
+        :param runtime_crate_dir: Path to the runtime crate
+        :param executable_file: Path to the executable to load and run
+        :param gdbserver_port: The port number to use to connect to the local
+            GDB server
+        :param terminal_io_port: The port number to connect to optionally read
+            text output from the target program.
+        """
+        self.terminal_io_port = terminal_io_port
+
         gdb_path = find_gdb(runtime_crate_dir, "arm-eabi")
 
         if gdb_path is None:
@@ -97,27 +87,65 @@ class JLinkInterface(GdbInterface):
                 f"Failed to find GDB in Alire environment for {runtime_crate_dir.name}"
             )
 
-        super(JLinkInterface, self).__init__(
-            gdb_path=find_gdb(runtime_crate_dir, "arm-eabi"),
-            gdbserver_port=gdbserver_port,
+        self.gdb = pygdbmi.gdbcontroller.GdbController(
+            [str(gdb_path), "--interpreter=mi2", str(executable_file.absolute())]
         )
-        self.gdb.write("monitor semihosting enable")
 
-        self.terminal_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.terminal_socket.connect(("localhost", terminal_io_port))
-        self.terminal_socket.setblocking(False)
+        # Clear any opening messages sent by GDB
+        self.gdb.get_gdb_response(raise_error_on_timeout=False)
+
+        # Connect to the GDB server
+        self._write(
+            f"-target-select extended-remote :{gdbserver_port}", read_response=False
+        )
+        self._wait_for_result(timeout_sec=5.0)
+
+        self.enable_semihosting()
+
+        if terminal_io_port is None:
+            self.terminal_socket = None
+        else:
+            self.terminal_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.terminal_socket.connect(("localhost", terminal_io_port))
+            self.terminal_socket.setblocking(False)
+
+    def __enter__(self):
+        return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        super(JLinkInterface, self).__exit__(exc_type, exc_value, exc_traceback)
-        self.terminal_socket.close()
+        self.shutdown()
 
-    def reset(self):
-        # The reset seems to be more reliable with two reset commands
-        super(JLinkInterface, self).reset()
-        super(JLinkInterface, self).reset()
+    def shutdown(self):
+        """Gracefully shut down the GDB session"""
+        if self.terminal_socket is not None:
+            self.terminal_socket.close()
+        self.gdb.exit()
+
+    def load(self):
+        """Load the executable onto the target"""
+        res = self._write(f"-target-download", read_response=False)
+        self._wait_for_result(timeout_sec=10.0)
+
+    def run(self):
+        """Run the program"""
+        self._write("-exec-continue")
+
+    def interrupt(self):
+        """Send SIGINT to interrupt GDB"""
+        self.gdb.gdb_process.send_signal(signal.SIGINT)
+
+    def monitor_command(
+        self, cmd: str, timeout_sec=pygdbmi.constants.DEFAULT_GDB_TIMEOUT_SEC
+    ):
+        """Send a command to the remote monitor"""
+        self._write(f'-interpreter-exec console "monitor {cmd}"', read_response=False)
+        self._wait_for_result()
 
     def read_io(self, timeout=5.0):
         """Read semihosting data from the target"""
+        if self.terminal_socket is None:
+            return bytes()
+
         ready = select.select([self.terminal_socket], [], [], timeout)
         if ready[0]:
             return self.terminal_socket.recv(4096)
@@ -147,3 +175,155 @@ class JLinkInterface(GdbInterface):
             output = before + sep
 
         return output
+
+    def _write(
+        self,
+        cmd: str,
+        timeout_sec: float = pygdbmi.constants.DEFAULT_GDB_TIMEOUT_SEC,
+        read_response=True,
+    ):
+        """Send a command to GDB"""
+        return self.gdb.write(cmd, timeout_sec=timeout_sec, read_response=read_response)
+
+    def _wait_for_result(
+        self,
+        timeout_sec: float = pygdbmi.constants.DEFAULT_GDB_TIMEOUT_SEC,
+    ):
+        """Wait for a response from GDB which has the 'result' type"""
+        now = time.time()
+        deadline = now + timeout_sec
+
+        while now <= deadline:
+            responses = self.gdb.get_gdb_response(
+                timeout_sec=deadline - now, raise_error_on_timeout=False
+            )
+
+            now = time.time()
+
+            for r in responses:
+                print(f"Got response: {r}")
+
+            for r in responses:
+                if r["type"] == "result":
+                    return r
+
+        raise pygdbmi.constants.GdbTimeoutError()
+
+
+class JLinkInterface(GdbTargetInterface):
+    """
+    Interfaces to the target via a J-Link GDB server
+    """
+
+    def __init__(
+        self,
+        runtime_crate_dir: pathlib.Path,
+        executable_file: pathlib.Path,
+        gdbserver_port: int,
+        terminal_io_port: int,
+    ):
+        super(JLinkInterface, self).__init__(
+            runtime_crate_dir=runtime_crate_dir,
+            executable_file=executable_file,
+            gdbserver_port=gdbserver_port,
+            terminal_io_port=terminal_io_port,
+        )
+
+    def enable_semihosting(self):
+        self.monitor_command("semihosting enable")
+
+    def reset(self):
+        # The reset seems to be more reliable with two reset commands
+        self.monitor_command("reset")
+        self.monitor_command("reset")
+
+
+class OpenOcdInterface(GdbTargetInterface):
+    """
+    Interfaces to the target via a OpenOCD GDB server
+    """
+
+    def __init__(
+        self,
+        runtime_crate_dir: pathlib.Path,
+        executable_file: pathlib.Path,
+        gdbserver_port: int,
+        terminal_io_port: int,
+    ):
+        super(OpenOcdInterface, self).__init__(
+            runtime_crate_dir=runtime_crate_dir,
+            executable_file=executable_file,
+            gdbserver_port=gdbserver_port,
+            terminal_io_port=terminal_io_port,
+        )
+
+    def enable_semihosting(self):
+        self.monitor_command("arm semihosting enable")
+
+    def reset(self):
+        self.monitor_command("reset halt")
+
+
+class StUtilInterface(GdbTargetInterface):
+    """
+    Interfaces to the target using st-util
+
+    This spawns an instance of st-util, then connects to its GDB server.
+    """
+
+    def __init__(
+        self,
+        runtime_crate_dir: pathlib.Path,
+        executable_file: pathlib.Path,
+        gdbserver_port: int,
+        terminal_io_port: int,
+    ):
+        self.stutil = subprocess.Popen(
+            ["st-util", "-v0", "-p", str(gdbserver_port)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        # Prevent read() from possibly blocking indefinitely
+        os.set_blocking(self.stutil.stderr.fileno(), False)
+        os.set_blocking(self.stutil.stdout.fileno(), False)
+
+        super(StUtilInterface, self).__init__(
+            runtime_crate_dir=runtime_crate_dir,
+            executable_file=executable_file,
+            gdbserver_port=gdbserver_port,
+            terminal_io_port=None,  # not used for st-util
+        )
+
+    def shutdown(self):
+        super(StUtilInterface, self).shutdown()
+
+        # st-util should exit when the GDB connection is closed, so wait for it
+        # to exit. If it doesn't exit quickly, then kill it.
+        try:
+            self.stutil.communicate(timeout=1.0)
+        except subprocess.TimeoutExpired:
+            self.stutil.kill()
+            self.stutil.communicate()
+
+    def enable_semihosting(self):
+        self.monitor_command("semihosting enable")
+
+    def reset(self):
+        self.monitor_command("reset")
+
+    def read_io(self, timeout=5.0):
+        # st-util prints semihosting data to stderr
+        ready = select.select([self.stutil.stderr.fileno()], [], [], timeout)
+        if ready[0]:
+            return self.stutil.stderr.read1()
+        else:
+            return bytes()
+
+
+driver_classes = {
+    "jlink-gdbserver": JLinkInterface,
+    "openocd-gdbserver": OpenOcdInterface,
+    "st-util": StUtilInterface,
+}
+

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -85,6 +85,7 @@ def test_execute_on_target(
     runtime_dir: str,
     crate_config_values: Dict[str, str],
     target_board,
+    target_if,
     gdbserver_port,
     text_io_port,
     working_dir: Optional[str],
@@ -140,12 +141,17 @@ def test_execute_on_target(
         p = tc.build()
         assert p.returncode == 0, "Build failed"
 
-        with JLinkInterface(
+        # Load the executable onto the target, run it, and check its output
+
+        driver = support.target_interface.driver_classes[target_if]
+
+        with driver(
             runtime_crate_dir=target_info.runtime_crate_dir,
+            executable_file=tc.executable_path,
             gdbserver_port=gdbserver_port,
             terminal_io_port=text_io_port,
         ) as target_if:
-            target_if.load(tc.executable_path)
+            target_if.load()
             target_if.reset()
             target_if.read_io(timeout=0.0)  # Clear input buffer
             target_if.run()
@@ -153,9 +159,9 @@ def test_execute_on_target(
             # Keep reading output until the TEST COMPLETE marker is found
 
             test_complete_marker = bytes("===TEST COMPLETE===", "ascii")
-            actual_output = target_if.read_io_until(test_complete_marker)
+            actual_output = target_if.read_io_until(test_complete_marker).decode('ascii')
 
             with open(testcase_dir / "test.out", "rb") as f:
-                expected_output = f.read()
+                expected_output = f.read().decode('ascii')
 
             assert actual_output == expected_output


### PR DESCRIPTION
The --target-if option is added to allow selecting between J-Link, OpenOCD, and st-util.

OpenOCD support is not very reliable since OpenOCD 0.12.0 tends to segfault when the testsuite disconnects from the semihosting socket at the end of each testcase, but it's better than nothing for now.

The GDB interface is also overhauled to use GDB/MI commands instead of regular GDB commands, and to properly wait for a result from certain commands.

test/README.md is updated to reflect all of this, plus instructions on running the tests on the stm32g4xx target.