### PR TITLE
Fix heap allocation for light_tasking_rp2040 runtime

### DIFF
--- a/build-rts.py
+++ b/build-rts.py
@@ -443,8 +443,14 @@ class Stm32F0(arm.cortexm.CortexM0CommonArchSupport):
         # We use our own version of System.BB.Parameters
         self.remove_source("s-bbpara.ads")
 
+        # Use our own version of s-bbarat, which adds __atomic_compare_exchange_4
+        self.remove_source("s-bbarat.ads")
+        self.remove_source("s-bbarat.adb")
+
         # Common source files
         self.add_gnat_sources(
+            "common_src/s-bbarat.adb",
+            "common_src/s-bbarat.ads",
             "stm32f0_src/s-stm32.ads",
             "stm32f0_src/s-stm32.adb",
             "stm32f0_src/start-rom.S",
@@ -505,8 +511,14 @@ class Stm32G0(arm.cortexm.CortexM0P):
         self.add_linker_script("stm32g0_src/ld/common-RAM.ld")
         self.add_linker_script("stm32g0_src/ld/common-ROM.ld")
 
+        # Use our own version of s-bbarat, which adds __atomic_compare_exchange_4
+        self.remove_source("s-bbarat.ads")
+        self.remove_source("s-bbarat.adb")
+
         # Common source files
         self.add_gnat_sources(
+            "common_src/s-bbarat.adb",
+            "common_src/s-bbarat.ads",
             "stm32g0_src/start-rom.S",
             "stm32g0_src/start-ram.S",
             "stm32g0_src/setup_pll.ads",

--- a/build-rts.py
+++ b/build-rts.py
@@ -71,19 +71,19 @@ class RP2040(arm.cortexm.CortexM0P):
             "rp2040_src/s-bootro.adb",
             "rp2040_src/setup_clocks.adb",
             "rp2040_src/s-bbbopa.ads",
+            "rp2040_src/s-bbpara.ads",
+            "rp2040_src/s-bbrpat.ads",
+            "rp2040_src/s-bbrpat.adb",
         )
 
         # s-maxres__cortexm3.adb is also compatible with Cortex-M0+
         self.add_gnat_sources("src/s-macres__cortexm3.adb")
 
         # Common GNARL sources
-        self.add_gnarl_sources("rp2040_src/s-bbpara.ads")
-
         self.add_gnarl_sources(
             "rp2040_src/a-intnam-1.ads",
             "rp2040_src/a-intnam-2.ads",
             "rp2040_src/s-bbbosu.adb",
-            "rp2040_src/s-bbpara.ads",
             "rp2040_src/s-bbsumu.adb",
             "rp2040_src/s-bcpcst.adb",
             "src/s-bbcppr__armv7m.adb",

--- a/common_src/s-bbarat.adb
+++ b/common_src/s-bbarat.adb
@@ -1,0 +1,205 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT RUN-TIME COMPONENTS                         --
+--                                                                          --
+--            Copyright (C) AdaCore and other contributors, 2022            --
+--      See https://github.com/AdaCore/bb-runtimes/graphs/contributors      --
+--                           for more information                           --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with System.Machine_Code;   use System.Machine_Code;
+with Interfaces;            use Interfaces;
+
+package body System.BB.Armv6m_Atomic is
+
+   -------------
+   -- PRIMASK --
+   -------------
+
+   function PRIMASK return Unsigned_32 is
+      R : Unsigned_32;
+   begin
+      Asm ("mrs %0, PRIMASK", Outputs => Unsigned_32'Asm_Output ("=r", R),
+           Volatile => True);
+      return R;
+   end PRIMASK;
+
+   ------------------------
+   -- Interrupt_Disabled --
+   ------------------------
+
+   function Interrupt_Disabled return Boolean
+   is ((PRIMASK and 1) /= 0);
+
+   ------------------------
+   -- Disable_Interrupts --
+   ------------------------
+
+   procedure Disable_Interrupts is
+   begin
+      Asm ("cpsid i" & ASCII.CR & ASCII.LF
+             & "dsb" & ASCII.CR & ASCII.LF
+             & "isb",
+           Clobber => "memory",
+           Volatile => True);
+   end Disable_Interrupts;
+
+   -----------------------
+   -- Enable_Interrupts --
+   -----------------------
+
+   procedure Enable_Interrupts is
+   begin
+      Asm ("cpsie i" & ASCII.CR & ASCII.LF
+             & "dsb" & ASCII.CR & ASCII.LF
+             & "isb",
+           Clobber => "memory",
+           Volatile => True);
+   end Enable_Interrupts;
+
+   --------------------
+   -- Atomic_Wrapper --
+   --------------------
+
+   procedure Atomic_Wrapper is
+      Already_Disabled : constant Boolean := Interrupt_Disabled;
+      --  Make sure not to change the status of interrupt control by checking
+      --  if they are enabled when entering the function.
+   begin
+
+      if not Already_Disabled then
+         Disable_Interrupts;
+      end if;
+
+      Wrapped_Proc;
+
+      --  If the interrupts were disabled when entering this function, we do
+      --  not want enable them.
+      if not Already_Disabled then
+         Enable_Interrupts;
+      end if;
+   end Atomic_Wrapper;
+
+   ----------------------------
+   -- Sync_Lock_Test_And_Set --
+   ----------------------------
+
+   function Sync_Lock_Test_And_Set (Addr  : System.Address;
+                                    Value : T)
+                                   return T
+   is
+      Data : T with Address => Addr;
+      Ret  : T;
+
+      procedure Inner
+        with Inline_Always;
+
+      procedure Inner
+      is
+      begin
+         Ret  := Data;
+         Data := Value;
+      end Inner;
+
+      procedure Atomic_Action is new Atomic_Wrapper (Inner);
+
+   begin
+      Atomic_Action;
+      return Ret;
+   end Sync_Lock_Test_And_Set;
+
+   --------------------------------
+   -- Sync_Bool_Compare_And_Swap --
+   --------------------------------
+
+   function Sync_Bool_Compare_And_Swap (Addr      : System.Address;
+                                        Old_Value : T;
+                                        New_Value : T)
+                                       return Interfaces.C.char
+   is
+      Data : T with Address => Addr;
+      Ret  : Interfaces.C.char;
+
+      procedure Inner
+        with Inline_Always;
+
+      procedure Inner
+      is
+      begin
+         if Data = Old_Value then
+            Data := New_Value;
+            Ret := Interfaces.C.char'Succ (Interfaces.C.nul); -- True
+         else
+            Ret := Interfaces.C.nul; -- False
+         end if;
+      end Inner;
+
+      procedure Atomic_Action is new Atomic_Wrapper (Inner);
+
+   begin
+      Atomic_Action;
+      return Ret;
+   end Sync_Bool_Compare_And_Swap;
+
+   -----------------------------
+   -- Atomic_Compare_Exchange --
+   -----------------------------
+
+   function Atomic_Compare_Exchange
+     (Ptr           : Address;
+      Expected      : Address;
+      Desired       : T;
+      Weak          : Interfaces.C.char;
+      Success_Model : SAP.Mem_Model;
+      Failure_Model : SAP.Mem_Model) return Interfaces.C.char
+   is
+      pragma Unreferenced (Weak);
+      pragma Unreferenced (Success_Model);
+      pragma Unreferenced (Failure_Model);
+
+      Ptr_Value      : T with Address => Ptr;
+      Expected_Value : T with Address => Expected;
+      Ret            : Interfaces.C.char;
+
+      procedure Inner
+        with Inline_Always;
+
+      procedure Inner
+      is
+      begin
+         if Ptr_Value = Expected_Value then
+            Ptr_Value := Desired;
+            Ret := Interfaces.C.char'Succ (Interfaces.C.nul); -- True
+         else
+            Ret := Interfaces.C.nul; -- False
+         end if;
+      end Inner;
+
+      procedure Atomic_Action is new Atomic_Wrapper (Inner);
+
+   begin
+      Atomic_Action;
+      return Ret;
+   end Atomic_Compare_Exchange;
+
+end System.BB.Armv6m_Atomic;

--- a/common_src/s-bbarat.ads
+++ b/common_src/s-bbarat.ads
@@ -1,0 +1,112 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT RUN-TIME COMPONENTS                         --
+--                                                                          --
+--            Copyright (C) AdaCore and other contributors, 2022            --
+--      See https://github.com/AdaCore/bb-runtimes/graphs/contributors      --
+--                           for more information                           --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This package implements some intrinsics not provided by GCC for the armv6m
+--  architecture.
+
+with Interfaces.C;
+
+with System.Atomic_Primitives;
+
+package System.BB.Armv6m_Atomic is
+
+   package SAP renames System.Atomic_Primitives;
+
+   ------------------------------
+   -- __sync_lock_test_and_set --
+   ------------------------------
+
+   generic
+      type T is mod <>;
+   function Sync_Lock_Test_And_Set (Addr  : System.Address;
+                                    Value : T)
+                                   return T;
+
+   function Sync_Lock_Test_And_Set_1 is
+      new Sync_Lock_Test_And_Set (Interfaces.Unsigned_8);
+   pragma Export (C, Sync_Lock_Test_And_Set_1,
+                  "__sync_lock_test_and_set_1");
+
+   ----------------------------------
+   -- __sync_bool_compare_and_swap --
+   ----------------------------------
+
+   generic
+      type T is mod <>;
+   function Sync_Bool_Compare_And_Swap (Addr      : System.Address;
+                                        Old_Value : T;
+                                        New_Value : T)
+                                       return Interfaces.C.char;
+
+   function Sync_Bool_Compare_And_Swap_4 is
+      new Sync_Bool_Compare_And_Swap (Interfaces.Unsigned_32);
+   pragma Export (C, Sync_Bool_Compare_And_Swap_4,
+                  "__sync_bool_compare_and_swap_4");
+
+   ---------------------------------
+   -- __atomic_compare_exchange_4 --
+   ---------------------------------
+
+   generic
+      type T is mod <>;
+   function Atomic_Compare_Exchange
+     (Ptr           : Address;
+      Expected      : Address;
+      Desired       : T;
+      Weak          : Interfaces.C.char;
+      Success_Model : SAP.Mem_Model;
+      Failure_Model : SAP.Mem_Model) return Interfaces.C.char;
+
+   function Atomic_Compare_Exchange_4 is new
+     Atomic_Compare_Exchange (Interfaces.Unsigned_32);
+   pragma Export (C, Atomic_Compare_Exchange_4,
+                  "__atomic_compare_exchange_4");
+
+private
+
+   function PRIMASK return Interfaces.Unsigned_32
+     with Inline_Always;
+
+   function Interrupt_Disabled return Boolean
+     with Inline_Always;
+
+   procedure Disable_Interrupts
+     with Inline_Always;
+
+   procedure Enable_Interrupts
+     with Inline_Always;
+
+   generic
+      with procedure Wrapped_Proc;
+   procedure Atomic_Wrapper
+     with Inline_Always;
+   --  Calls Wrapped_Proc with interrupts disabled
+   --  and the hardware spinlock obtained (locked).
+
+end System.BB.Armv6m_Atomic;

--- a/rp2040_src/s-bbrpat.adb
+++ b/rp2040_src/s-bbrpat.adb
@@ -196,4 +196,45 @@ package body System.BB.RP2040_Atomic is
       return Ret;
    end Sync_Bool_Compare_And_Swap;
 
+   -----------------------------
+   -- Atomic_Compare_Exchange --
+   -----------------------------
+
+   function Atomic_Compare_Exchange
+     (Ptr           : Address;
+      Expected      : Address;
+      Desired       : T;
+      Weak          : Interfaces.C.char;
+      Success_Model : SAP.Mem_Model;
+      Failure_Model : SAP.Mem_Model) return Interfaces.C.char
+   is
+      pragma Unreferenced (Weak);
+      pragma Unreferenced (Success_Model);
+      pragma Unreferenced (Failure_Model);
+
+      Ptr_Value      : T with Address => Ptr;
+      Expected_Value : T with Address => Expected;
+      Ret            : Interfaces.C.char;
+
+      procedure Inner
+        with Inline_Always;
+
+      procedure Inner
+      is
+      begin
+         if Ptr_Value = Expected_Value then
+            Ptr_Value := Desired;
+            Ret := Interfaces.C.char'Succ (Interfaces.C.nul); -- True
+         else
+            Ret := Interfaces.C.nul; -- False
+         end if;
+      end Inner;
+
+      procedure Atomic_Action is new Atomic_Wrapper (Inner);
+
+   begin
+      Atomic_Action;
+      return Ret;
+   end Atomic_Compare_Exchange;
+
 end System.BB.RP2040_Atomic;

--- a/rp2040_src/s-bbrpat.ads
+++ b/rp2040_src/s-bbrpat.ads
@@ -33,7 +33,11 @@
 
 with Interfaces.C;
 
+with System.Atomic_Primitives;
+
 package System.BB.RP2040_Atomic is
+
+   package SAP renames System.Atomic_Primitives;
 
    ------------------------------
    -- __sync_lock_test_and_set --
@@ -65,6 +69,25 @@ package System.BB.RP2040_Atomic is
       new Sync_Bool_Compare_And_Swap (Interfaces.Unsigned_32);
    pragma Export (C, Sync_Bool_Compare_And_Swap_4,
                   "__sync_bool_compare_and_swap_4");
+
+   ---------------------------------
+   -- __atomic_compare_exchange_4 --
+   ---------------------------------
+
+   generic
+      type T is mod <>;
+   function Atomic_Compare_Exchange
+     (Ptr           : Address;
+      Expected      : Address;
+      Desired       : T;
+      Weak          : Interfaces.C.char;
+      Success_Model : SAP.Mem_Model;
+      Failure_Model : SAP.Mem_Model) return Interfaces.C.char;
+
+   function Atomic_Compare_Exchange_4 is new
+     Atomic_Compare_Exchange (Interfaces.Unsigned_32);
+   pragma Export (C, Atomic_Compare_Exchange_4,
+                  "__atomic_compare_exchange_4");
 
 private
 

--- a/tests/testcases/heap_alloc/test.adb
+++ b/tests/testcases/heap_alloc/test.adb
@@ -1,0 +1,10 @@
+with Ada.Text_IO;
+
+procedure Test is
+   type Int_Acc is access Integer;
+
+   X : Int_Acc := new Integer'(123);
+begin
+   Ada.Text_IO.Put_Line (X.all'Image);
+   Ada.Text_IO.Put_Line ("===TEST COMPLETE===");
+end Test;

--- a/tests/testcases/heap_alloc/test.out
+++ b/tests/testcases/heap_alloc/test.out
@@ -1,0 +1,2 @@
+ 123
+===TEST COMPLETE===


### PR DESCRIPTION
This implements `__atomic_compare_exchange_4` for the RP2040 by disabling interrupts and using one of the RP2040 spinlocks (when in a multicore configuration). This is needed by `s-memory.adb` to atomically update the pointer to the top of the heap.

Also added a regression test which reproduces the problem.

Fixes #22 