### PR TITLE
Set Externally_Built to prevent GNATprove from trying to analyse the runtime

### DIFF
--- a/nrf52_src/templates/ravenscar_build.gpr.in
+++ b/nrf52_src/templates/ravenscar_build.gpr.in
@@ -18,6 +18,14 @@ project Ravenscar_Build is
 
    for Source_Dirs use ("gnarl_user", "gnarl");
 
+   GPR_Tool := external ("GPR_TOOL", "");
+   case GPR_Tool is
+      when "gnatprove" =>
+         for Externally_Built use "True";
+      when others =>
+         null;
+   end case;
+
    package Compiler is
       for Default_Switches ("C") use Target_Options.GNARL_CFLAGS;
       for Default_Switches ("Ada") use Target_Options.GNARL_ADAFLAGS & ("-gnaty-d");

--- a/nrf52_src/templates/runtime_build.gpr.nrf52832.in
+++ b/nrf52_src/templates/runtime_build.gpr.nrf52832.in
@@ -16,6 +16,14 @@ project Runtime_Build is
 
   for Source_Dirs use ("gnat_user", "gnat");
 
+  GPR_Tool := external ("GPR_TOOL", "");
+  case GPR_Tool is
+    when "gnatprove" =>
+      for Externally_Built use "True";
+    when others =>
+      null;
+  end case;
+
   package Naming is
      for Spec_Suffix ("Asm_CPP") use ".inc";
       for Spec ("Interfaces.NRF52")           use "i-nrf52.ads";

--- a/nrf52_src/templates/runtime_build.gpr.nrf52833.in
+++ b/nrf52_src/templates/runtime_build.gpr.nrf52833.in
@@ -16,6 +16,14 @@ project Runtime_Build is
 
   for Source_Dirs use ("gnat_user", "gnat");
 
+  GPR_Tool := external ("GPR_TOOL", "");
+  case GPR_Tool is
+    when "gnatprove" =>
+      for Externally_Built use "True";
+    when others =>
+      null;
+  end case;
+
   package Naming is
      for Spec_Suffix ("Asm_CPP") use ".inc";
       for Spec ("Interfaces.NRF52")           use "i-nrf52.ads";

--- a/nrf52_src/templates/runtime_build.gpr.nrf52840.in
+++ b/nrf52_src/templates/runtime_build.gpr.nrf52840.in
@@ -16,6 +16,14 @@ project Runtime_Build is
 
   for Source_Dirs use ("gnat_user", "gnat");
 
+  GPR_Tool := external ("GPR_TOOL", "");
+  case GPR_Tool is
+    when "gnatprove" =>
+      for Externally_Built use "True";
+    when others =>
+      null;
+  end case;
+
   package Naming is
      for Spec_Suffix ("Asm_CPP") use ".inc";
       for Spec ("Interfaces.NRF52")       use "i-nrf52.ads";

--- a/nrf54l_src/templates/ravenscar_build.gpr.in
+++ b/nrf54l_src/templates/ravenscar_build.gpr.in
@@ -19,6 +19,14 @@ project Ravenscar_Build is
 
    for Source_Dirs use ("gnarl_user", "gnarl");
 
+   GPR_Tool := external ("GPR_TOOL", "");
+   case GPR_Tool is
+      when "gnatprove" =>
+         for Externally_Built use "True";
+      when others =>
+         null;
+   end case;
+
    --  Exclude sources that are not needed for the specified MCU config
 
    Excluded_Sources := ();

--- a/nrf54l_src/templates/runtime_build.gpr.in
+++ b/nrf54l_src/templates/runtime_build.gpr.in
@@ -17,6 +17,14 @@ project Runtime_Build is
 
   for Source_Dirs use ("gnat_user", "gnat");
 
+  GPR_Tool := external ("GPR_TOOL", "");
+  case GPR_Tool is
+    when "gnatprove" =>
+      for Externally_Built use "True";
+    when others =>
+      null;
+  end case;
+
   --  Select linker script
 
   type Loaders is ("ROM", "USER");

--- a/rp2040_src/templates/ravenscar_build.gpr.in
+++ b/rp2040_src/templates/ravenscar_build.gpr.in
@@ -19,6 +19,14 @@ project Ravenscar_Build is
 
    for Source_Dirs use ("gnarl_user", "gnarl");
 
+   GPR_Tool := external ("GPR_TOOL", "");
+   case GPR_Tool is
+      when "gnatprove" =>
+         for Externally_Built use "True";
+      when others =>
+         null;
+   end case;
+
    --  Exclude sources that are not needed for the specified MCU config
 
    Excluded_Sources := ();

--- a/rp2040_src/templates/runtime_build.gpr.in
+++ b/rp2040_src/templates/runtime_build.gpr.in
@@ -17,6 +17,14 @@ project Runtime_Build is
 
    for Source_Dirs use ("gnat_user", "gnat");
 
+   GPR_Tool := external ("GPR_TOOL", "");
+   case GPR_Tool is
+      when "gnatprove" =>
+         for Externally_Built use "True";
+      when others =>
+         null;
+   end case;
+
    Excluded_Sources := ();
 
    --  Choose the flash chip based on the board

--- a/rp2350_src/templates/ravenscar_build.gpr.in
+++ b/rp2350_src/templates/ravenscar_build.gpr.in
@@ -19,6 +19,14 @@ project Ravenscar_Build is
 
    for Source_Dirs use ("gnarl_user", "gnarl");
 
+   GPR_Tool := external ("GPR_TOOL", "");
+   case GPR_Tool is
+      when "gnatprove" =>
+         for Externally_Built use "True";
+      when others =>
+         null;
+   end case;
+
    --  Exclude sources that are not needed for the specified MCU config
 
    Excluded_Sources := ();

--- a/rp2350_src/templates/runtime_build.gpr.in
+++ b/rp2350_src/templates/runtime_build.gpr.in
@@ -17,6 +17,14 @@ project Runtime_Build is
 
    for Source_Dirs use ("gnat_user", "gnat");
 
+   GPR_Tool := external ("GPR_TOOL", "");
+   case GPR_Tool is
+      when "gnatprove" =>
+         for Externally_Built use "True";
+      when others =>
+         null;
+   end case;
+
    Excluded_Sources := ();
 
    --  Choose the flash size (in MB) based on the board

--- a/stm32f0_src/templates/ravenscar_build.gpr.in
+++ b/stm32f0_src/templates/ravenscar_build.gpr.in
@@ -18,6 +18,14 @@ project Ravenscar_Build is
 
    for Source_Dirs use ("gnarl_user", "gnarl");
 
+   GPR_Tool := external ("GPR_TOOL", "");
+   case GPR_Tool is
+      when "gnatprove" =>
+         for Externally_Built use "True";
+      when others =>
+         null;
+   end case;
+
    --  Exclude sources that are not needed for the specified MCU config
 
    Excluded_Sources := ();

--- a/stm32f0_src/templates/runtime_build.gpr.in
+++ b/stm32f0_src/templates/runtime_build.gpr.in
@@ -17,6 +17,14 @@ project Runtime_Build is
 
   for Source_Dirs use ("gnat_user", "gnat");
 
+  GPR_Tool := external ("GPR_TOOL", "");
+  case GPR_Tool is
+    when "gnatprove" =>
+      for Externally_Built use "True";
+    when others =>
+      null;
+  end case;
+
   Excluded_Sources := ();
 
   ROM_Size := "16";

--- a/stm32g0_src/templates/ravenscar_build.gpr.in
+++ b/stm32g0_src/templates/ravenscar_build.gpr.in
@@ -18,6 +18,14 @@ project Ravenscar_Build is
 
    for Source_Dirs use ("gnarl_user", "gnarl");
 
+   GPR_Tool := external ("GPR_TOOL", "");
+   case GPR_Tool is
+      when "gnatprove" =>
+         for Externally_Built use "True";
+      when others =>
+         null;
+   end case;
+
    --  Exclude sources that are not needed for the specified MCU config
 
    Excluded_Sources := ();

--- a/stm32g0_src/templates/runtime_build.gpr.in
+++ b/stm32g0_src/templates/runtime_build.gpr.in
@@ -17,6 +17,14 @@ project Runtime_Build is
 
   for Source_Dirs use ("gnat_user", "gnat");
 
+  GPR_Tool := external ("GPR_TOOL", "");
+  case GPR_Tool is
+    when "gnatprove" =>
+      for Externally_Built use "True";
+    when others =>
+      null;
+  end case;
+
   Excluded_Sources := ();
 
   ROM_Size := "16";

--- a/stm32g4_src/templates/ravenscar_build.gpr.in
+++ b/stm32g4_src/templates/ravenscar_build.gpr.in
@@ -19,6 +19,14 @@ project Ravenscar_Build is
 
    for Source_Dirs use ("gnarl_user", "gnarl");
 
+   GPR_Tool := external ("GPR_TOOL", "");
+   case GPR_Tool is
+      when "gnatprove" =>
+         for Externally_Built use "True";
+      when others =>
+         null;
+   end case;
+
    --  Exclude sources that are not needed for the specified MCU config
 
    Excluded_Sources := ();

--- a/stm32g4_src/templates/runtime_build.gpr.in
+++ b/stm32g4_src/templates/runtime_build.gpr.in
@@ -17,6 +17,14 @@ project Runtime_Build is
 
   for Source_Dirs use ("gnat_user", "gnat");
 
+  GPR_Tool := external ("GPR_TOOL", "");
+  case GPR_Tool is
+    when "gnatprove" =>
+      for Externally_Built use "True";
+    when others =>
+      null;
+  end case;
+
   Excluded_Sources := ();
 
   ROM_Size := "32";


### PR DESCRIPTION
This uses the GPR_TOOL external variable to detect when GNATprove is running on the runtime_build.gpr and ravenscar_build.gpr files, in which case Externally_Built is set to True to prevent GNATprove from analysing the runtime sources.

This is necessary since some versions of GNATprove have problems processing certain runtime units. For example, GNAT FSF 15 errors out on a-synbar.adb due to the use of the 'Count attribute on an entry, which this version of GNATprove erroneously thinks is not permitted when pure-barriers is in effect. These problems are avoided by preventing GNATprove from trying to analyse the runtime as a whole.

The reason why GNATprove tries to process the runtime sources is because the expected usage of these runtime crates is to "with" runtime_build.gpr and/or ravenscar_build.gpr in the user's GPR project, so the runtime project files are automatically included as subprojects in the user's project. By default, GNATprove tries to prove all subprojects, which would include the runtime in this case.

Other GNAT runtimes do not have this problem because they are not "with"ed as a subproject, and are instead selected using the --RTS switch or `for Runtime ("Ada") use "<path>";`, so GNATprove does not see them as a subproject. This would not work for community-bb-runtimes crates, however, because this ensures the runtime is built properly as part of the project build, and because some attributes of the runtime project files need to be referenced in the user's project file (such as Target, Runtime, and sometimes also Linker_Options).