### PR TITLE
rp2040,rp2350: Don't enable interrupts during Initialize_Board

### DIFF
--- a/rp2040_src/s-bbbosu.adb
+++ b/rp2040_src/s-bbbosu.adb
@@ -164,8 +164,6 @@ package body System.BB.Board_Support is
 
       Install_Trap_Handler
         (Interrupt_Handler'Address, Interrupt_Request_Vector);
-
-      Enable_Interrupts (Priority'Last);
    end Initialize_Board;
 
    package body Time is

--- a/rp2350_src/s-bbbosu.adb
+++ b/rp2350_src/s-bbbosu.adb
@@ -199,8 +199,6 @@ package body System.BB.Board_Support is
 
       Install_Trap_Handler
         (Interrupt_Handler'Address, Interrupt_Request_Vector);
-
-      Enable_Interrupts (Priority'Last);
    end Initialize_Board;
 
    package body Time is

--- a/tests/testcases/test_exceptions/opt.py
+++ b/tests/testcases/test_exceptions/opt.py
@@ -1,0 +1,9 @@
+import support.target_info
+import pytest
+
+
+def check_test_conditions(target_info: support.target_info.TargetInfo):
+    if target_info.runtime_profile != "embedded":
+        pytest.skip(
+            f"Test is not applicable for '{target_info.runtime_profile}' runtimes"
+        )

--- a/tests/testcases/test_exceptions/test.adb
+++ b/tests/testcases/test_exceptions/test.adb
@@ -1,0 +1,27 @@
+with Ada.Text_IO;
+with Ada.Exceptions;
+
+--  Test with all the tasking stuff in the closure too
+
+with Ada.Real_Time;
+pragma Unreferenced (Ada.Real_Time);
+
+procedure Test is
+   procedure Raise_Ex with No_Inline is
+   begin
+      raise Constraint_Error with "Hello";
+   end Raise_Ex;
+begin
+   Raise_Ex;
+   Ada.Text_IO.Put_Line ("Exception not caught!");
+   Ada.Text_IO.Put_Line ("===TEST COMPLETE===");
+
+exception
+   when Ex : Constraint_Error =>
+      Ada.Text_IO.Put_Line ("Caught: " & Ada.Exceptions.Exception_Name (Ex));
+
+      Ada.Text_IO.Put_Line
+        ("Message: " & Ada.Exceptions.Exception_Message (Ex));
+
+      Ada.Text_IO.Put_Line ("===TEST COMPLETE===");
+end Test;

--- a/tests/testcases/test_exceptions/test.out
+++ b/tests/testcases/test_exceptions/test.out
@@ -1,0 +1,3 @@
+Caught: CONSTRAINT_ERROR
+Message: Hello
+===TEST COMPLETE===


### PR DESCRIPTION
The runtime does not expect interrupts to be enabled at this point, and the runtime will enable interrupts later once everything else is initialized. Having interrupts trigger early can cause a crash since the Interrupt_Wrapper will try to change task priorities before threads are initialized.

Also added a test to verify that exception propagation works correctly, since the original report on the Ada forum indicated that their problem only occurred when `Ada.Exceptions` was used. Though this turned out to be a red herring in the end.

Fixes #27