### PR TITLE
Make interrupt stack sizes configurable

### DIFF
--- a/nrf52_src/README.md
+++ b/nrf52_src/README.md
@@ -130,6 +130,29 @@ light_tasking_nrf52840.LFCLK_Src = "RC"
 light_tasking_nrf52840.Time_Base = "RTC0"
 ```
 
+The following variables configure the interrupt stack sizes:
+
+<table>
+  <thead>
+    <th>Variable</th>
+    <th>Values</th>
+    <th>Default</th>
+    <th>Description</th>
+  </thead>
+  <tr>
+    <td><tt>Interrupt_Stack_Size</tt></td>
+    <td>Any positive integer</td>
+    <td><tt>1024</tt></td>
+    <td>Specifies the size of the primary stack used for interrupt handlers.</td>
+  </tr>
+  <tr>
+    <td><tt>Interrupt_Secondary_Stack_Size</tt></td>
+    <td>Any positive integer</td>
+    <td><tt>128</tt></td>
+    <td>Specifies the size of the secondary stack used for interrupt handlers.</td>
+  </tr>
+</table>
+
 ### GPR Scenario Variables
 
 The runtime project files expose `*_BUILD` and and `*_LIBRARY_TYPE` GPR

--- a/nrf52_src/s-bbpara.ads
+++ b/nrf52_src/s-bbpara.ads
@@ -40,11 +40,14 @@
 
 --  This is the nRF52840 (ARMv7) version of this package
 
+pragma Restrictions (No_Elaboration_Code);
+
 with System.BB.Board_Parameters;
 with System.BB.MCU_Parameters;
 
+with NRF52_Runtime_Config;
+
 package System.BB.Parameters is
-   pragma No_Elaboration_Code_All;
    pragma Preelaborate (System.BB.Parameters);
 
    Clock_Frequency : constant := Board_Parameters.Main_Clock_Frequency;
@@ -98,12 +101,14 @@ package System.BB.Parameters is
    -- Stacks --
    ------------
 
-   Interrupt_Stack_Size : constant := 2 * 1024;
+   Interrupt_Stack_Size : constant :=
+     NRF52_Runtime_Config.Interrupt_Stack_Size;
    --  Size of each of the interrupt stacks in bytes. While there nominally is
    --  an interrupt stack per interrupt priority, the entire space is used as a
    --  single stack.
 
-   Interrupt_Sec_Stack_Size : constant := 128;
+   Interrupt_Sec_Stack_Size : constant :=
+     NRF52_Runtime_Config.Interrupt_Secondary_Stack_Size;
    --  Size of the secondary stack for interrupt handlers
 
    Has_FPU : constant Boolean := True;

--- a/nrf52_src/templates/alire.toml.in
+++ b/nrf52_src/templates/alire.toml.in
@@ -44,5 +44,8 @@ LFCLK_Src = { type = "Enum", values = ["Xtal", "RC", "Synth"], default = "Xtal" 
 Use_SWO_Trace = { type = "Boolean", default = true }
 Use_Reset_Pin = { type = "Boolean", default = true }
 
+Interrupt_Stack_Size = { type = "Integer", first = 1, default = 1024 }
+Interrupt_Secondary_Stack_Size = { type = "Integer", first = 1, default = 128 }
+
 [[depends-on]]
 gnat_arm_elf = "^15"

--- a/nrf52_src/templates/ravenscar_build.gpr.in
+++ b/nrf52_src/templates/ravenscar_build.gpr.in
@@ -34,11 +34,12 @@ project Ravenscar_Build is
       --  Always build System.BB.CPU_Primitives at -O2 as some targets may make
       --  use of inline assembly that rely on specific compiler behaviour to
       --  load constants that are not enabled at -O0.
-      for Switches ("s-bbcppr.adb") use Target_Options.GNARL_ADAFLAGS & ("-O2");
+      for Switches ("s-bbcppr.adb") use Target_Options.GNARL_ADAFLAGS
+        & ("-O2", "-gnaty-d");
       --  Some runtime files need to be compiled with debug info, so that gdb
       --  is not blind.
       for Switches ("s-tasdeb.adb") use Target_Options.ALL_ADAFLAGS
-        & ("-g", "-O0");
+        & ("-g", "-O0", "-gnaty-d");
    end Compiler;
 
 end Ravenscar_Build;

--- a/nrf54l_src/README.md
+++ b/nrf54l_src/README.md
@@ -219,6 +219,29 @@ light_tasking_nrf54l_app.LFCLK_Src = "LFRC"
 light_tasking_nrf54l_app.Time_Base_GRTC_IRQ = 0
 ```
 
+The following variables configure the interrupt stack sizes:
+
+<table>
+  <thead>
+    <th>Variable</th>
+    <th>Values</th>
+    <th>Default</th>
+    <th>Description</th>
+  </thead>
+  <tr>
+    <td><tt>Interrupt_Stack_Size</tt></td>
+    <td>Any positive integer</td>
+    <td><tt>1024</tt></td>
+    <td>Specifies the size of the primary stack used for interrupt handlers.</td>
+  </tr>
+  <tr>
+    <td><tt>Interrupt_Secondary_Stack_Size</tt></td>
+    <td>Any positive integer</td>
+    <td><tt>128</tt></td>
+    <td>Specifies the size of the secondary stack used for interrupt handlers.</td>
+  </tr>
+</table>
+
 ### GPR Scenario Variables
 
 The runtime project files expose `*_BUILD` and and `*_LIBRARY_TYPE` GPR

--- a/nrf54l_src/s-bbpara.ads
+++ b/nrf54l_src/s-bbpara.ads
@@ -40,11 +40,14 @@
 
 --  This is the nRF54L15 (ARMv8-M) version of this package
 
+pragma Restrictions (No_Elaboration_Code);
+
 with System.BB.Board_Parameters;
 with System.BB.MCU_Parameters;
 
+with NRF54_App_Runtime_Config;
+
 package System.BB.Parameters is
-   pragma No_Elaboration_Code_All;
    pragma Preelaborate (System.BB.Parameters);
 
    Clock_Frequency : constant := Board_Parameters.Main_Clock_Frequency;
@@ -98,12 +101,14 @@ package System.BB.Parameters is
    -- Stacks --
    ------------
 
-   Interrupt_Stack_Size : constant := 2 * 1024;
+   Interrupt_Stack_Size : constant :=
+     NRF54_App_Runtime_Config.Interrupt_Stack_Size;
    --  Size of each of the interrupt stacks in bytes. While there nominally is
    --  an interrupt stack per interrupt priority, the entire space is used as a
    --  single stack.
 
-   Interrupt_Sec_Stack_Size : constant := 128;
+   Interrupt_Sec_Stack_Size : constant :=
+     NRF54_App_Runtime_Config.Interrupt_Secondary_Stack_Size;
    --  Size of the secondary stack for interrupt handlers
 
    Has_FPU : constant Boolean := True;

--- a/nrf54l_src/templates/alire.toml.in
+++ b/nrf54l_src/templates/alire.toml.in
@@ -57,5 +57,8 @@ Enable_SWO = { type = "Boolean", default = true }
 Enable_Trace = { type = "Boolean", default = false }
 Enable_Glitch_Detector = { type = "Boolean", default = true }
 
+Interrupt_Stack_Size = { type = "Integer", first = 1, default = 1024 }
+Interrupt_Secondary_Stack_Size = { type = "Integer", first = 1, default = 128 }
+
 [[depends-on]]
 gnat_arm_elf = "^15"

--- a/nrf54l_src/templates/ravenscar_build.gpr.in
+++ b/nrf54l_src/templates/ravenscar_build.gpr.in
@@ -122,11 +122,12 @@ project Ravenscar_Build is
       --  Always build System.BB.CPU_Primitives at -O2 as some targets may make
       --  use of inline assembly that rely on specific compiler behaviour to
       --  load constants that are not enabled at -O0.
-      for Switches ("s-bbcppr.adb") use Target_Options.GNARL_ADAFLAGS & ("-O2");
+      for Switches ("s-bbcppr.adb") use Target_Options.GNARL_ADAFLAGS
+        & ("-O2", "-gnaty-d");
       --  Some runtime files need to be compiled with debug info, so that gdb
       --  is not blind.
       for Switches ("s-tasdeb.adb") use Target_Options.ALL_ADAFLAGS
-        & ("-g", "-O0");
+        & ("-g", "-O0", "-gnaty-d");
    end Compiler;
 
 end Ravenscar_Build;

--- a/stm32f0_src/README.md
+++ b/stm32f0_src/README.md
@@ -282,6 +282,29 @@ light_tasking_stm32f0xx.AHB_Pre = "DIV1"
 light_tasking_stm32f0xx.APB_Pre = "DIV1"
 ```
 
+The following variables configure the interrupt stack sizes:
+
+<table>
+  <thead>
+    <th>Variable</th>
+    <th>Values</th>
+    <th>Default</th>
+    <th>Description</th>
+  </thead>
+  <tr>
+    <td><tt>Interrupt_Stack_Size</tt></td>
+    <td>Any positive integer</td>
+    <td><tt>1024</tt></td>
+    <td>Specifies the size of the primary stack used for interrupt handlers.</td>
+  </tr>
+  <tr>
+    <td><tt>Interrupt_Secondary_Stack_Size</tt></td>
+    <td>Any positive integer</td>
+    <td><tt>128</tt></td>
+    <td>Specifies the size of the secondary stack used for interrupt handlers.</td>
+  </tr>
+</table>
+
 ### GPR Scenario Variables
 
 The runtime project files expose `*_BUILD` and and `*_LIBRARY_TYPE` GPR

--- a/stm32f0_src/s-bbpara.ads
+++ b/stm32f0_src/s-bbpara.ads
@@ -44,6 +44,8 @@ pragma Restrictions (No_Elaboration_Code);
 with System.BB.Board_Parameters;
 with System.BB.MCU_Parameters;
 
+with STM32F0xx_Runtime_Config;
+
 package System.BB.Parameters is
    pragma Preelaborate (System.BB.Parameters);
 
@@ -98,12 +100,14 @@ package System.BB.Parameters is
    -- Stacks --
    ------------
 
-   Interrupt_Stack_Size : constant := 1024;
+   Interrupt_Stack_Size : constant :=
+     STM32F0xx_Runtime_Config.Interrupt_Stack_Size;
    --  Size of each of the interrupt stacks in bytes. While there nominally is
    --  an interrupt stack per interrupt priority, the entire space is used as a
    --  single stack.
 
-   Interrupt_Sec_Stack_Size : constant := 128;
+   Interrupt_Sec_Stack_Size : constant :=
+     STM32F0xx_Runtime_Config.Interrupt_Secondary_Stack_Size;
    --  Size of the secondary stack for interrupt handlers
 
    Has_FPU : constant Boolean := False;

--- a/stm32f0_src/templates/alire.toml.in
+++ b/stm32f0_src/templates/alire.toml.in
@@ -99,5 +99,8 @@ PLLMUL = { type = "Integer", first = 2, last = 16, default = 12 }
 AHB_Pre = { type = "Enum", values = ["DIV1", "DIV2", "DIV4", "DIV8", "DIV16", "DIV64", "DIV128", "DIV256", "DIV512"], default = "DIV1" }
 APB_Pre = { type = "Enum", values = ["DIV1", "DIV2", "DIV4", "DIV8", "DIV16"], default = "DIV2" }
 
+Interrupt_Stack_Size = { type = "Integer", first = 1, default = 1024 }
+Interrupt_Secondary_Stack_Size = { type = "Integer", first = 1, default = 128 }
+
 [[depends-on]]
 gnat_arm_elf = "^15"


### PR DESCRIPTION
Some runtimes have configurable interrupt stack sizes but others don't. This fills in the gaps so that all runtimes have configurable stack sizes.