### PR TITLE
nrf52: Fix wrong template variable substitution in alire.toml

### DIFF
--- a/nrf52_src/templates/alire.toml.in
+++ b/nrf52_src/templates/alire.toml.in
@@ -15,12 +15,12 @@ First edit your `alire.toml` file and add the following elements:
 Then edit your project file to add the following elements:
  - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
    ```ada
-   with "$(runtime_proj_prefix)_build.gpr";
+$(project_file_withs)
    ```
  - Specify the `Target` and `Runtime` attributes:
    ```ada
-      for Target use $(runtime_proj_prefix)_build'Target;
-      for Runtime ("Ada") use $(runtime_proj_prefix)_build'Runtime ("Ada");
+      for Target use Runtime_Build'Target;
+      for Runtime ("Ada") use Runtime_Build'Runtime ("Ada");
    ```
 """
 

--- a/patch-runtime.py
+++ b/patch-runtime.py
@@ -5,7 +5,9 @@
 
 import argparse
 import pathlib
+import re
 import shutil
+import sys
 import tomllib
 from typing import Dict
 
@@ -77,6 +79,25 @@ def gen_from_template(
     for key, value in template_values.items():
         content = content.replace(f"$({key})", value)
 
+    # Check for any unrecognised template variables
+    m = re.search(r"\$\([^\)]+\)", content)
+    if m:
+        print(
+            f"Error: unrecognised template variable '{m.group(0)}'"
+            f" in file {str(template_file)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    m = re.search(r"\$\(\w*", content)
+    if m:
+        print(
+            f"Error: malformed template variable '{m.group(0)}'"
+            f" in file {str(template_file)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     with open(out_file, "w", newline="\n") as f:
         f.write(content)
 
@@ -101,10 +122,10 @@ def gen_templates_from_manifest(
                     src = template_info["src"]
                     dst = template_info["dst"]
 
-                    for k,v in template_values.items():
+                    for k, v in template_values.items():
                         src = src.replace(f"$({k})", v)
 
-                    for k,v in template_values.items():
+                    for k, v in template_values.items():
                         dst = dst.replace(f"$({k})", v)
 
                     gen_from_template(


### PR DESCRIPTION
The nrf52's `alire.toml` was referenced a non-existent template variable `$(runtime_proj_prefix)`. This is now fixed.

Also added some additional checks in `patch-runtime.py` to guard against such cases in the future.

